### PR TITLE
Changed versions requirement for aws/aws-sdk-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "aws/aws-sdk-php": "2.5.2"
+        "aws/aws-sdk-php": "^2"
     },
     "require-dev": {
         "phpunit/phpunit": "4.0.9"


### PR DESCRIPTION
There is no need to require specifically `2.5.2` version of `aws/aws-sdk-php`.

I changed requirement to install any release with major version of 2.
